### PR TITLE
log.cleanup.interval.mins was replaced…

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -57,10 +57,10 @@ class kafka::defaults {
 
     $log_retention_hours                 = 168     # 1 week
     $log_retention_bytes                 = undef
+    $log_retention_check_interval_ms     = 300000 # 5 minutes
     $log_segment_bytes                   = 536870912
 
     $log_cleanup_policy                  = 'delete'
-    $log_cleanup_interval_mins           = 1
 
     $metrics_properties                  = undef
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -163,9 +163,9 @@ class kafka::server(
     $log_flush_interval_ms               = $kafka::defaults::log_flush_interval_ms,
     $log_retention_hours                 = $kafka::defaults::log_retention_hours,
     $log_retention_bytes                 = $kafka::defaults::log_retention_bytes,
+    $log_retention_check_interval_ms     = $kafka::defaults::log_retention_check_interval_ms,
     $log_segment_bytes                   = $kafka::defaults::log_segment_bytes,
 
-    $log_cleanup_interval_mins           = $kafka::defaults::log_cleanup_interval_mins,
     $log_cleanup_policy                  = $kafka::defaults::log_cleanup_policy,
 
     $metrics_properties                  = $kafka::defaults::metrics_properties,

--- a/templates/server.properties.erb
+++ b/templates/server.properties.erb
@@ -128,7 +128,7 @@ log.segment.bytes=<%= @log_segment_bytes %>
 
 # The interval at which log segments are checked to see if they can be deleted according
 # to the retention policies
-log.cleanup.interval.mins=<%= @log_cleanup_interval_mins %>
+<%= @log_retention_check_interval_ms ? "log.retention.check.interval.ms=#{@log_retention_check_interval_ms}" : "#log.retention.check.interval.ms=" %>
 
 log.cleanup.policy=<%= @log_cleanup_policy %>
 


### PR DESCRIPTION
…with log.retention.check.interval.ms per https://issues.apache.org/jira/browse/KAFKA-1113

This causes a non-fatal warning when starting the Kafka service and probably has the effect of the setting itself not doing anything